### PR TITLE
Fix compiler error C2664 on MSVC 2017

### DIFF
--- a/network_win32.cpp
+++ b/network_win32.cpp
@@ -1052,7 +1052,7 @@ static bool SetIPV6DnsOnInterface(NET_LUID *InterfaceLuid, const uint8 new_addre
   if (ConvertInterfaceLuidToIndex(InterfaceLuid, &InterfaceIndex))
     return false;
   if (IsIpv6AddressSet(new_address)) {
-    if (!inet_ntop(AF_INET6, new_address, ipv6, sizeof(ipv6)))
+    if (!inet_ntop(AF_INET6, const_cast<uint8*>(new_address), ipv6, sizeof(ipv6)))
       return false;
 
     snprintf(buf, sizeof(buf), "netsh interface ipv6 set dns name=%d static %s validate=no", InterfaceIndex, ipv6);


### PR DESCRIPTION
The error message was: C2664: 'PCSTR inet_ntop(INT,PVOID,PSTR,size_t)': cannot convert argument 2 from 'const uint8 []' to 'PVOID'

BTW, I thought you're going to keep it closed source. May I ask what makes you change the decision? Pardon me if you already discussed it somewhere, I didn't found it.
