### PR TITLE
fixed for issue 15

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -5,8 +5,8 @@ RELARGS="-O3 -DNDEBUG"
 DBGARGS="-g -D_DEBUG"
 CURARGS="$RELARGS"
 
-clang++-6.0 -c -march=skylake-avx512 crypto/poly1305/poly1305-x64-linux.s crypto/chacha20/chacha20-x64-linux.s
-clang++-6.0 -I . $CURARGS -DWITH_NETWORK_BSD=1 -mssse3 -pthread -lrt -o tunsafe \
+clang++- -c -march=skylake-avx512 crypto/poly1305/poly1305-x64-linux.s crypto/chacha20/chacha20-x64-linux.s
+clang++- -I . $CURARGS -DWITH_NETWORK_BSD=1 -mssse3 -pthread -lrt -o tunsafe \
 tunsafe_amalgam.cpp \
 crypto/aesgcm/aesni_gcm-x64-linux.s \
 crypto/aesgcm/aesni-x64-linux.s \


### PR DESCRIPTION
see issue - https://github.com/TunSafe/TunSafe/issues/15

I have tested on Arch x86_64 using clang 7.0.1, Target: x86_64-pc-linux-gnu

git clone https://github.com/TunSafe/TunSafe.git
cd TunSafe
sudo pacman -S clang gcc7
make
sudo make install